### PR TITLE
Fix building of QWaylandIntegration if some Qt5 features are disabled.

### DIFF
--- a/src/client/qwaylandintegration.cpp
+++ b/src/client/qwaylandintegration.cpp
@@ -39,7 +39,9 @@
 #include "qwaylandinputcontext_p.h"
 #include "qwaylandshmbackingstore_p.h"
 #include "qwaylandnativeinterface_p.h"
+#ifndef QT_NO_CLIPBOARD
 #include "qwaylandclipboard_p.h"
+#endif
 #include "qwaylanddnd_p.h"
 #include "qwaylandwindowmanagerintegration_p.h"
 #include "qwaylandscreen_p.h"
@@ -57,7 +59,9 @@
 #include <QSocketNotifier>
 
 #include <qpa/qplatforminputcontextfactory_p.h>
+#ifndef QT_NO_ACCESSIBILITY
 #include <qpa/qplatformaccessibility.h>
+#endif
 #include <qpa/qplatforminputcontext.h>
 
 #include "qwaylandhardwareintegration_p.h"
@@ -119,8 +123,6 @@ QWaylandIntegration::QWaylandIntegration()
     , mNativeInterface(new QWaylandNativeInterface(this))
 #ifndef QT_NO_ACCESSIBILITY
     , mAccessibility(new QPlatformAccessibility())
-#else
-    , mAccessibility(0)
 #endif
     , mClientBufferIntegrationInitialized(false)
     , mServerBufferIntegrationInitialized(false)
@@ -128,9 +130,12 @@ QWaylandIntegration::QWaylandIntegration()
 {
     initializeInputDeviceIntegration();
     mDisplay = new QWaylandDisplay(this);
+#ifndef QT_NO_CLIPBOARD
     mClipboard = new QWaylandClipboard(mDisplay);
+#endif
+#ifndef QT_NO_DRAGANDDROP
     mDrag = new QWaylandDrag(mDisplay);
-
+#endif
     QString icStr = QPlatformInputContextFactory::requested();
     icStr.isNull() ? mInputContext.reset(new QWaylandInputContext(mDisplay))
                    : mInputContext.reset(QPlatformInputContextFactory::create(icStr));
@@ -138,8 +143,12 @@ QWaylandIntegration::QWaylandIntegration()
 
 QWaylandIntegration::~QWaylandIntegration()
 {
+#ifndef QT_NO_DRAGANDDROP
     delete mDrag;
+#endif
+#ifndef QT_NO_CLIPBOARD
     delete mClipboard;
+#endif
 #ifndef QT_NO_ACCESSIBILITY
     delete mAccessibility;
 #endif
@@ -215,15 +224,19 @@ QPlatformFontDatabase *QWaylandIntegration::fontDatabase() const
     return mFontDb;
 }
 
+#ifndef QT_NO_CLIPBOARD
 QPlatformClipboard *QWaylandIntegration::clipboard() const
 {
     return mClipboard;
 }
+#endif
 
+#ifndef QT_NO_DRAGANDDROP
 QPlatformDrag *QWaylandIntegration::drag() const
 {
     return mDrag;
 }
+#endif
 
 QPlatformInputContext *QWaylandIntegration::inputContext() const
 {
@@ -245,10 +258,12 @@ QVariant QWaylandIntegration::styleHint(StyleHint hint) const
     return QPlatformIntegration::styleHint(hint);
 }
 
+#ifndef QT_NO_ACCESSIBILITY
 QPlatformAccessibility *QWaylandIntegration::accessibility() const
 {
     return mAccessibility;
 }
+#endif
 
 QPlatformServices *QWaylandIntegration::services() const
 {

--- a/src/client/qwaylandintegration_p.h
+++ b/src/client/qwaylandintegration_p.h
@@ -80,15 +80,21 @@ public:
 
     QPlatformNativeInterface *nativeInterface() const Q_DECL_OVERRIDE;
 
+#ifndef QT_NO_CLIPBOARD
     QPlatformClipboard *clipboard() const Q_DECL_OVERRIDE;
+#endif
 
+#ifndef QT_NO_DRAGANDDROP
     QPlatformDrag *drag() const Q_DECL_OVERRIDE;
+#endif
 
     QPlatformInputContext *inputContext() const Q_DECL_OVERRIDE;
 
     QVariant styleHint(StyleHint hint) const Q_DECL_OVERRIDE;
 
+#ifndef QT_NO_ACCESSIBILITY
     QPlatformAccessibility *accessibility() const Q_DECL_OVERRIDE;
+#endif
 
     QPlatformServices *services() const Q_DECL_OVERRIDE;
 
@@ -118,12 +124,18 @@ private:
     QWaylandShellIntegration *createShellIntegration(const QString& interfaceName);
 
     QPlatformFontDatabase *mFontDb;
+#ifndef QT_NO_CLIPBOARD
     QPlatformClipboard *mClipboard;
+#endif
+#ifndef QT_NO_DRAGANDDROP
     QPlatformDrag *mDrag;
+#endif
     QWaylandDisplay *mDisplay;
     QPlatformNativeInterface *mNativeInterface;
     QScopedPointer<QPlatformInputContext> mInputContext;
+#ifndef QT_NO_ACCESSIBILITY
     QPlatformAccessibility *mAccessibility;
+#endif
     bool mClientBufferIntegrationInitialized;
     bool mServerBufferIntegrationInitialized;
     bool mShellIntegrationInitialized;


### PR DESCRIPTION
QPlatformIntegration's interface methods are disabled based on QT_NO_OPENGL,
QT_NO_CLIPBOARD, QT_NO_DRAGANDDROP, QT_NO_ACCESSIBILITY and
QT_NO_SESSIONMANAGER, these has to be taken into account when compiling
QtWayland.