### PR TITLE
Fix black screen observed on some platforms.

### DIFF
--- a/src/compositor/wayland_wrapper/qwlclientbuffer.cpp
+++ b/src/compositor/wayland_wrapper/qwlclientbuffer.cpp
@@ -168,6 +168,10 @@ QOpenGLTexture *SharedMemoryBuffer::toOpenGlTexture(int plane)
             m_textureDirty = false;
             m_shmTexture->bind();
             glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_NEAREST);
+			// Next 2 settings will handle the case when texture is npot (non power of two)
+			// and extension OES_texture_npot is not present
+            glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
+            glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
             // TODO: partial texture upload
             QImage image = this->image();
             m_shmTexture->setSize(image.width(), image.height());


### PR DESCRIPTION
Added handling of a case when the texture is npot and OES_texture_npot is not present for gles.

On OpenGL ES 2 core implementation, only GL_CLAMP_TO_EDGE parameter is supported as wrap mode for NPOT (non-power of two dimensions) textures. Initially, wrap modes are set to GL_REPEAT.

An extension OES_texture_npot (Available on most of the modern platform), however, adds the support of other GL_REPEAT and GL_MIRRORED_REPEAT to the wrap modes. But this extension may not be present on every target.