### PR TITLE
Fix mutex use after free

### DIFF
--- a/src/client/qwaylanddisplay.cpp
+++ b/src/client/qwaylanddisplay.cpp
@@ -371,11 +371,11 @@ QWaylandDisplay::~QWaylandDisplay(void)
 #if QT_CONFIG(cursor)
     mCursorThemes.clear();
 #endif
-    if (mDisplay)
-        wl_display_disconnect(mDisplay);
 
     if (m_frameEventQueue)
         wl_event_queue_destroy(m_frameEventQueue);
+    if (mDisplay)
+        wl_display_disconnect(mDisplay);
 }
 
 // Steps which is called just after constructor. This separates registry_global() out of the constructor


### PR DESCRIPTION
wl_display_disconnect() destroys the mutex that wl_event_queue_destroy() tries to take